### PR TITLE
Fixed typo w/ -ll switch

### DIFF
--- a/rhel/init.sh
+++ b/rhel/init.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-while true; do echo -e "HTTP/1.1 200 OK\n\n$(date)\nHost: $(tail -1 /etc/hosts| awk '{print $2}')" | nc -ll -p 8080; done
+while true; do echo -e "HTTP/1.1 200 OK\n\n$(date)\nHost: $(tail -1 /etc/hosts| awk '{print $2}')" | nc -l -p 8080; done
 


### PR DESCRIPTION
I believe this to be a typo, `nc` in the man pages that I've checked doesn't include `-ll` as an option, merely a single `-l` to listen.